### PR TITLE
feat: add support for clang 10 (which requires ubuntu 18)

### DIFF
--- a/clang-10/Dockerfile
+++ b/clang-10/Dockerfile
@@ -1,6 +1,6 @@
 FROM axom/compilers:ubuntu-18-base
 
-LABEL maintainer="David Beckingsale <david@llnl.gov>"
+LABEL maintainer="Josh Essman <essman1@llnl.gov>"
 
 ENV llvmver=10.0.0
 ENV llvmtar=clang+llvm-10.0.0-x86_64-linux-gnu-ubuntu-18.04

--- a/clang-10/Dockerfile
+++ b/clang-10/Dockerfile
@@ -1,0 +1,17 @@
+FROM axom/compilers:ubuntu-18-base
+
+LABEL maintainer="David Beckingsale <david@llnl.gov>"
+
+ENV llvmver=10.0.0
+ENV llvmtar=clang+llvm-10.0.0-x86_64-linux-gnu-ubuntu-18.04
+ENV tarext=.tar.xz
+
+RUN \
+    wget -q --no-check-certificate https://github.com/llvm/llvm-project/releases/download/llvmorg-${llvmver}/${llvmtar}${tarext} \
+    && tar xf ${llvmtar}${tarext} \
+    && sudo cp -fR ${llvmtar}/* /usr \
+    && rm -rf ${llvmtar} \
+    && rm ${llvmtar}${tarext}
+
+USER axom
+WORKDIR /home/axom

--- a/ubuntu-18-base/Dockerfile
+++ b/ubuntu-18-base/Dockerfile
@@ -1,0 +1,10 @@
+FROM ubuntu:18.04
+
+LABEL maintainer="David Beckingsale <david@llnl.gov>"
+
+ADD generic-setup.sh /root/generic-setup.sh
+
+RUN /root/generic-setup.sh
+
+USER axom
+WORKDIR /home/axom

--- a/ubuntu-18-base/Dockerfile
+++ b/ubuntu-18-base/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:18.04
 
-LABEL maintainer="David Beckingsale <david@llnl.gov>"
+LABEL maintainer="Josh Essman <essman1@llnl.gov>"
 
 ADD generic-setup.sh /root/generic-setup.sh
 

--- a/ubuntu-18-base/generic-setup.sh
+++ b/ubuntu-18-base/generic-setup.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+set -e
+set -x
+
+apt-get -qq update
+apt-get -qq install -y --no-install-recommends wget python3-dev python3-pip build-essential sudo git vim dh-autoreconf ninja-build ca-certificates valgrind
+
+wget -q --no-check-certificate https://cmake.org/files/v3.18/cmake-3.18.0-Linux-x86_64.tar.gz
+tar -xzf cmake-3.18.0-Linux-x86_64.tar.gz
+rm -r cmake-3.18.0-Linux-x86_64/share/vim/vimfiles
+cp -fR cmake-3.18.0-Linux-x86_64/* /usr
+rm -rf cmake-3.18.0-Linux-x86_64
+rm cmake-3.18.0-Linux-x86_64.tar.gz
+
+useradd -ms /bin/bash axom
+printf "axom:axom" | chpasswd
+adduser axom sudo
+printf "axom ALL= NOPASSWD: ALL\\n" >> /etc/sudoers


### PR DESCRIPTION
LLVM's only Ubuntu release is for 18.04, so I created a new 18.04 base image with the latest version of CMake (3.18), which has C++17/20 support.