### PR TITLE
oneapi/dpcpp 2021.2.0 docker changes.

### DIFF
--- a/ubuntu-16/oneapi/Dockerfile
+++ b/ubuntu-16/oneapi/Dockerfile
@@ -1,4 +1,4 @@
-FROM axom/compilers:ubuntu-base
+FROM axom/compilers:gcc-8
 
 LABEL maintainer="David Beckingsale <david@llnl.gov>"
 

--- a/ubuntu-16/oneapi/entrypoint.sh
+++ b/ubuntu-16/oneapi/entrypoint.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -e
 
-source /opt/intel/inteloneapi/setvars.sh 
+source /opt/intel/oneapi/setvars.sh
 exec "$@"
 


### PR DESCRIPTION
## Summary
Changes for building oneapi image with the latest dpcpp. 

This PR:
- Changes setvar script source to the new directory of the oneapi install location. 
- Uses the gcc-8 axom image as the base container to avoid compilation errors when compiling with dpcpp later on.