### PR TITLE
Feature/white238/clangformat10

### DIFF
--- a/ubuntu-20/clang-10/Dockerfile
+++ b/ubuntu-20/clang-10/Dockerfile
@@ -4,11 +4,12 @@ LABEL maintainer="Josh Essman <essman1@llnl.gov>"
 
 RUN \
        sudo apt-get -qq install -y --no-install-recommends \
-         clang-10 llvm-10 \
+         clang-10 clang-format-10 llvm-10 \
     && sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-10 100 \
     && sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-10 100 \
     && sudo update-alternatives --install /usr/bin/cc cc /usr/bin/clang-10 100 \
     && sudo update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++-10 100 \
+    && sudo update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-10 100 \
     && sudo update-alternatives --install /usr/bin/llvm-cov llvm-cov /usr/bin/llvm-cov-10 100
 USER axom
 WORKDIR /home/axom

--- a/ubuntu-20/clang-10/Dockerfile
+++ b/ubuntu-20/clang-10/Dockerfile
@@ -3,8 +3,8 @@ FROM axom/compilers:ubuntu-20-base_latest
 LABEL maintainer="Josh Essman <essman1@llnl.gov>"
 
 RUN \
-       sudo apt-get -qq install -y --no-install-recommends \
-         clang-10 clang-format-10 llvm-10 \
+    sudo apt-get -qq install -y --no-install-recommends \
+        clang-10 clang-format-10 llvm-10 \
     && sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-10 100 \
     && sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-10 100 \
     && sudo update-alternatives --install /usr/bin/cc cc /usr/bin/clang-10 100 \


### PR DESCRIPTION
Apparently the `llvm` package doesn't contain any of the clang-tools.  You can install them all via `clang-tools` or individually.  The super package is almost 20mbs and `clang-format-10` is only 200kb.